### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cobs==1.2.0
-fastplotlib
+fastplotlib[notebook]
 install==1.3.5
 jupyter-rfb==0.3.3
 poetry==1.5.1
@@ -8,5 +8,3 @@ poetry-plugin-export==1.4.0
 scanimage-tiff-reader==1.4.1
 scipy==1.10.1
 seaborn==0.12.2
-sidecar==0.7.0
-


### PR DESCRIPTION
I just noticed from our dependency graph that you're using fastplotlib for calcium imaging analysis :smile: 

To make installation smoother, you will need to specify `fastplotib[notebook]` since only specifying `fastplotlib` just gets you the minimal install without any framework (i.e. without the jupyter dependencies). See https://github.com/fastplotlib/fastplotlib#notebook

Also, the latest `fastplotlib` works with sidecar by default, so sidecar doesn't need to be specified separately. Note that this will give you the latest version of sidecar, not sure if you've pinned it to a previous version for some other reason.

Let us know if you have any issues/question with fastplotlib :smile:
